### PR TITLE
Fix when token is null, will cache invalid cache value

### DIFF
--- a/weixin4j-base/src/main/java/com/foxinmy/weixin4j/cache/CacheManager.java
+++ b/weixin4j-base/src/main/java/com/foxinmy/weixin4j/cache/CacheManager.java
@@ -40,7 +40,9 @@ public class CacheManager<T extends Cacheable> {
 					cache = cacheStorager.lookup(cacheKey);
 					if (cache == null) {
 						cache = cacheCreator.create();
-						cacheStorager.caching(cacheKey, cache);
+						if (cache != null) {
+							cacheStorager.caching(cacheKey, cache);
+						}
 					}
 				} finally {
 					lock.unlock();


### PR DESCRIPTION
I encountered this issue, not sure why the token is null.