### PR TITLE
Fixed model classes that lost data during fastjson serialization

### DIFF
--- a/weixin4j-pay/pom.xml
+++ b/weixin4j-pay/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <name>weixin4j-pay</name>
     <artifactId>weixin4j-pay</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <url>https://github.com/foxinmy/weixin4j/tree/master/weixin4j-pay</url>
     <description>微信支付商户平台API</description>
     <developers>

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/PayPackage.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/PayPackage.java
@@ -81,7 +81,7 @@ public class PayPackage extends MerchantResult {
 	@JSONField(name = "goods_tag")
 	private String goodsTag;
 
-	protected PayPackage() {
+	public PayPackage() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/PayRequest.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/PayRequest.java
@@ -33,7 +33,7 @@ public class PayRequest extends PayBaseInfo {
 	private String partnerId;
 
 
-	protected PayRequest() {
+	public PayRequest() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/coupon/OrderCouponInfo.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/coupon/OrderCouponInfo.java
@@ -51,7 +51,7 @@ public class OrderCouponInfo implements Serializable {
 	@JSONField(name = "coupon_fee")
 	private Integer couponFee;
 
-	protected OrderCouponInfo() {
+	public OrderCouponInfo() {
 		// jaxb requried
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/coupon/RefundCouponInfo.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/coupon/RefundCouponInfo.java
@@ -42,7 +42,7 @@ public class RefundCouponInfo implements Serializable {
 	@JSONField(name = "coupon_refund_fee")
 	private Integer couponFee;
 
-	protected RefundCouponInfo() {
+	public RefundCouponInfo() {
 		// jaxb requried
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPayment.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPayment.java
@@ -64,7 +64,7 @@ public class CorpPayment extends MerchantResult {
 	@JSONField(name = "spbill_create_ip")
 	private String clientIp;
 
-	protected CorpPayment() {
+	public CorpPayment() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPaymentRecord.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPaymentRecord.java
@@ -93,7 +93,7 @@ public class CorpPaymentRecord extends MerchantResult {
 	@XmlElement(name = "check_name_result")
 	private String checkNameResult;
 
-	protected CorpPaymentRecord() {
+	public CorpPaymentRecord() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPaymentResult.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/CorpPaymentResult.java
@@ -43,7 +43,7 @@ public class CorpPaymentResult extends MerchantResult {
 	@XmlElement(name = "payment_time")
 	private String paymentTime;
 
-	protected CorpPaymentResult() {
+	public CorpPaymentResult() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MICROPayRequest.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MICROPayRequest.java
@@ -27,7 +27,7 @@ public class MICROPayRequest extends Order implements MchPayRequest {
 	@JSONField(serialize = false)
 	private WeixinPayAccount paymentAccount;
 
-	protected MICROPayRequest() {
+	public MICROPayRequest() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MchPayPackage.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MchPayPackage.java
@@ -90,7 +90,7 @@ public class MchPayPackage extends PayPackage {
 	@JSONField(name = "deposit")
 	private DepositType deposit;
 
-	protected MchPayPackage() {
+	public MchPayPackage() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MerchantResult.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/MerchantResult.java
@@ -75,7 +75,7 @@ public class MerchantResult extends XmlResult {
 	 */
 	private String recall;
 
-	protected MerchantResult() {
+	public MerchantResult() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/NativePayNotify.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/NativePayNotify.java
@@ -34,7 +34,7 @@ public class NativePayNotify extends OpenIdResult {
 	@JSONField(name = "product_id")
 	private String productId;
 
-	protected NativePayNotify() {
+	public NativePayNotify() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/NativePayResponse.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/NativePayResponse.java
@@ -30,7 +30,7 @@ public class NativePayResponse extends MerchantResult {
 	@JSONField(name = "prepay_id")
 	private String prepayId;
 
-	protected NativePayResponse() {
+	public NativePayResponse() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/Order.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/Order.java
@@ -120,7 +120,7 @@ public class Order extends MerchantTradeResult {
 	@JSONField(name = "sub_is_subscribe")
 	private String subIsSubscribe;
 
-	protected Order() {
+	public Order() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/PrePay.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/PrePay.java
@@ -39,7 +39,7 @@ public class PrePay extends MerchantResult {
 			@XmlElement(name = "mweb_url") })
 	private String payUrl;
 
-	protected PrePay() {
+	public PrePay() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/Redpacket.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/Redpacket.java
@@ -110,7 +110,7 @@ public class Redpacket extends MerchantResult {
 	@JSONField(name = "risk_info")
 	private String risk;
 
-	protected Redpacket() {
+	public Redpacket() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RedpacketSendResult.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RedpacketSendResult.java
@@ -54,7 +54,7 @@ public class RedpacketSendResult extends MerchantResult {
 	@JSONField(name = "send_listid")
 	private String sendListid;
 
-	protected RedpacketSendResult() {
+	public RedpacketSendResult() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundDetail.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundDetail.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class RefundDetail implements Serializable {
 	private static final long serialVersionUID = 1402738803019986864L;
 
-	protected RefundDetail() {
+	public RefundDetail() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundRecord.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundRecord.java
@@ -42,7 +42,7 @@ public class RefundRecord extends MerchantTradeResult {
 	@ListsuffixResult({ ".*(_\\d)$" })
 	private List<RefundDetail> refundList;
 
-	protected RefundRecord() {
+	public RefundRecord() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundResult.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/RefundResult.java
@@ -63,7 +63,7 @@ public class RefundResult extends MerchantTradeResult {
 	@ListsuffixResult({ ".*(_\\d)$" })
 	private List<RefundDetail> refundList;
 
-	protected RefundResult() {
+	public RefundResult() {
 		// jaxb required
 	}
 

--- a/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/SettlementRecord.java
+++ b/weixin4j-pay/src/main/java/com/foxinmy/weixin4j/pay/payment/mch/SettlementRecord.java
@@ -87,7 +87,7 @@ public class SettlementRecord extends MerchantResult {
 	@JSONField(name = "poundage_fee")
 	private int poundageFee;
 
-	protected SettlementRecord() {
+	public SettlementRecord() {
 		// jaxb required
 	}
 


### PR DESCRIPTION
由于fastjson对json数据序列化为对象时需要公共的无参构造方法（否则使用有参数的构造方法进行序列化），现将pay模块下边的model类对象的无参构造函数改为public