### PR TITLE
fix(sec): upgrade io.netty:netty-codec-http to 4.1.86.final

### DIFF
--- a/weixin4j-server/pom.xml
+++ b/weixin4j-server/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec-http</artifactId>
-			<version>4.1.86.Final</version>
+			<version>4.1.86.final</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-http 4.1.86.Final
- [CVE-2022-41915](https://www.oscs1024.com/hd/CVE-2022-41915)


### What did I do？
Upgrade io.netty:netty-codec-http from 4.1.86.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS