### PR TITLE
fix(sec): upgrade org.springframework:spring-webmvc to 6.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-webmvc</artifactId>
-				<version>5.3.18</version>
+				<version>6.0.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.alibaba</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-webmvc 5.3.18
- [CVE-2023-20860](https://www.oscs1024.com/hd/CVE-2023-20860)


### What did I do？
Upgrade org.springframework:spring-webmvc from 5.3.18 to 6.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS